### PR TITLE
Merge to "develop" from "TEG-111_Cambiar_label_de_los_modales"

### DIFF
--- a/teg_asovac_src/main_app/views.py
+++ b/teg_asovac_src/main_app/views.py
@@ -1584,50 +1584,61 @@ def load_subareas_modal(request):
 #                            Carga de usuarios via files                          #
 #---------------------------------------------------------------------------------#
 @login_required
-def load_users_modal(request,arbitraje_id,rol):
-    data=dict()
+def load_users_modal(request, arbitraje_id, rol):
+    data = dict()
+    # Crear titulo del modal en base al rol indicado.
+    if rol == '2':
+        modal_title = 'Cargar Coordinadores Generales'
+    elif rol == '3':
+        modal_title = 'Cargar Coordinadores de Áreas'
+    elif rol == '4':
+        modal_title = 'Cargar Árbitros'
+    elif rol == '5':
+        modal_title = 'Cargar Autores'
+    else:
+        modal_title = 'Cargar Usuarios'
 
     if request.method == 'POST':
-        print 'el metodo es post'
-        form= UploadFileForm(request.POST, request.FILES)
+        #print 'el metodo es post'
+        form = UploadFileForm(request.POST, request.FILES)
         if form.is_valid():
 
             # Para guardar el archivo de forma local
-            file_name= save_file(request,"usuarios")
-            extension= get_extension_file(file_name)
+            file_name = save_file(request, "usuarios")
+            extension = get_extension_file(file_name)
 
-            #Valida el contenido del archivo 
-            response= validate_load_users(file_name, extension,arbitraje_id,rol)
-            print response
+            #Valida el contenido del archivo
+            response = validate_load_users(file_name, extension, arbitraje_id, rol)
+            #print response
 
-            context={
-                'title': "Cargar Usuarios",
+            context = {
+                'title': modal_title,
                 'response': response['message'],
                 'status': response['status'],
             }
 
-            data['html_form']= render_to_string('ajax/modal_succes.html',context, request=request)
-            return JsonResponse(data) 
-        else:
-            form= UploadFileForm(request.POST, request.FILES)
-            context={
-            'form': form,
-            'arbitraje_id': arbitraje_id,
-            'rol': rol,
-            }
-            data['html_form']= render_to_string('ajax/load_users.html',context, request=request)
-            return JsonResponse(data) 
-    else:
-        print 'el metodo es get'
-        form= UploadFileForm()
-
-        context={
+            data['html_form'] = render_to_string('ajax/modal_succes.html', context, request=request)
+            return JsonResponse(data)
+        # Si el formulario no es valido regresarlo con errores.
+        context = {
+            'title': modal_title,
             'form': form,
             'arbitraje_id': arbitraje_id,
             'rol': rol,
         }
-        data['html_form']= render_to_string('ajax/load_users.html',context, request=request)
-        return JsonResponse(data) 
+        data['html_form'] = render_to_string('ajax/load_users.html', context, request=request)
+        return JsonResponse(data)
+
+    #print 'el metodo es get'
+    form = UploadFileForm()
+    context = {
+        'title': modal_title,
+        'form': form,
+        'arbitraje_id': arbitraje_id,
+        'rol': rol
+    }
+    data['html_form'] = render_to_string('ajax/load_users.html', context, request=request)
+    return JsonResponse(data)
 
 #---------------------------------------------------------------------------------#
 #                 Valida el contenido del excel para cargar áreas                 #

--- a/teg_asovac_src/templates/ajax/load_users.html
+++ b/teg_asovac_src/templates/ajax/load_users.html
@@ -1,27 +1,28 @@
 {% load crispy_forms_tags %}
 <form enctype="multipart/form-data" action="" id="loadUsersForm" method="post" class="loadUsersForm" data-url="{% url 'main_app:load_users' arbitraje_id rol %}">
     {% csrf_token %}
-    
+
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
             <span aria-hidden="true">&times;</span>
         </button>
-        <h3 class="modal-title" >Cargar Usuarios</h3>
+        <h3 class="modal-title">{{ title }}</h3>
     </div>
+
     <div class="modal-body">
         {% include "errors_form.html" %}
         {{  form | crispy }}
     </div>
+
     <div class="modal-footer">
       <!-- Default switch -->
-        <label class="bs-switch">
+        <label class="bs-switch"></label>
         <button type="button" class="btn btn-danger btn-lg" data-dismiss="modal">Cancelar</button>
-        <button type="submit" class="btn btn-primary btn-lg" >Guardar</button>
+        <button type="submit" class="btn btn-primary btn-lg">Cargar</button>
     </div>
 </form>
 
 <script>
-   
      $('#loadUsersForm').submit(function(e){
         e.preventDefault();
         var input = document.getElementById('id_file');

--- a/teg_asovac_src/templates/ajax/modal_succes.html
+++ b/teg_asovac_src/templates/ajax/modal_succes.html
@@ -1,26 +1,26 @@
 <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-        <span aria-hidden="true">&times;</span>
+    <span aria-hidden="true">&times;</span>
     </button>
-    <h3 class="modal-title" >{{title}}</h3>
+    <h3 class="modal-title">{{ title }}</h3>
 </div>
+
 <div class="modal-body">
-    
     {% if status == 200 %}
         <div class="alert alert-success alert-dismissible" role="alert">
             {% include "errors_form.html" %}
             <strong>{{ response }}</strong>
         </div>
     {% else %}
-    <div class="alert alert-danger alert-dismissible" role="alert">
-        {% include "errors_form.html" %}
-        <strong>{{ response }}</strong>
-    </div>
+        <div class="alert alert-danger alert-dismissible" role="alert">
+            {% include "errors_form.html" %}
+            <strong>{{ response }}</strong>
+        </div>
     {% endif %}
-
 </div>
+
 <div class="modal-footer">
     <!-- Default switch -->
-    <label class="bs-switch">
+    <label class="bs-switch"></label>
     <button type="button" class="btn btn-danger btn-lg" data-dismiss="modal">Cerrar</button>
 </div>

--- a/teg_asovac_src/templates/main_app_users_list.html
+++ b/teg_asovac_src/templates/main_app_users_list.html
@@ -61,16 +61,24 @@
 										<a  href="#" class="show-form" data-url="{% url 'main_app:crear_usuario' %}" type="button" data-toggle="modal" data-target="#ModalTrabajosExcel"><i class="fas fa-plus-circle"></i> Crear usuario</a>
 									</li> -->
 									<li>
-										<a href="#" class="showUsersForm" data-url="{% url 'main_app:load_users' arbitraje_id 3 %}" type="button" data-toggle="modal" data-target="#ModalTrabajosExcel"><i class="fa fa-upload"></i> Cargar <br> Coordinadores  de Área</a>
+										<a href="#" class="showUsersForm" data-url="{% url 'main_app:load_users' arbitraje_id 3 %}" type="button" data-toggle="modal" data-target="#ModalTrabajosExcel">
+											<i class="fa fa-upload"></i> Cargar <br> Coordinadores de Área
+										</a>
 									</li>
 									<li>
-										<a class="Descargar" href="/media/cargamasiva/Coordinadores_de_area.xlsx" title="Descargar coordinadores de área" download="convencion_asovac_{{date}}_coordinadores_de_área.xlsx"> <i class="fas fa-file-download"></i> Descargar <br>Coordinadores de Área</a>
+										<a class="Descargar" href="/media/cargamasiva/Coordinadores_de_area.xlsx" title="Descargar coordinadores de área" download="convencion_asovac_{{date}}_coordinadores_de_área.xlsx">
+											<i class="fas fa-file-download"></i> Descargar <br>Coordinadores de Área
+										</a>
 									</li>
 									<li>
-										<a href="#" class="showUsersForm" data-url="{% url 'main_app:load_users' arbitraje_id 4 %}" type="button" data-toggle="modal" data-target="#ModalTrabajosExcel"><i class="fa fa-upload"></i> Cargar Árbitros</a>
+										<a href="#" class="showUsersForm" data-url="{% url 'main_app:load_users' arbitraje_id 4 %}" type="button" data-toggle="modal" data-target="#ModalTrabajosExcel">
+											<i class="fa fa-upload"></i> Cargar Árbitros
+										</a>
 									</li>
 									<li>
-										<a class="Descargar" href="/media/cargamasiva/Arbitros.xlsx" title="Descargar árbitros" download="convencion_asovac_{{date}}_arbitros.xlsx"> <i class="fas fa-file-download"></i> Descargar Árbitros</a>
+										<a class="Descargar" href="/media/cargamasiva/Arbitros.xlsx" title="Descargar árbitros" download="convencion_asovac_{{date}}_arbitros.xlsx">
+											<i class="fas fa-file-download"></i> Descargar Árbitros
+										</a>
 									</li>
 								</ul>
 							</div>


### PR DESCRIPTION
Add context sensitive modal title to user upload

- Adding a different title to the user upload modal depeding on the
submitted role number.
- Changing the main_app/views.py/load_users_modal function to comply
with PEP8 standard.
- Changing the ajax_load_users html template to accept a context sensitive
title.
- Fixing the lack of ending tags for labels in a couple of ajax templates
and extra unnecessary whitespace.
- Adding more nuanced indentation to the menu of the table of main_app
users list template.